### PR TITLE
Fix golang:alpine version to meet requirements

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ ENV NODE_ENV=production
 RUN make node-build
 
 # build-go image
-FROM golang:alpine as build-go
+FROM golang:1.19-alpine as build-go
 
 RUN apk add --no-cache g++ make
 COPY . /build/


### PR DESCRIPTION
The project needs at least go 1.18 to build, so hardcode it.

Without using a specific version that meets Go version requirements, it can use a locally cached image with a non-supported Go version.

Output from make docker-build when using an old, cached `golang:alpine` version:

```
go mod download
go mod tidy
go mod tidy: go.mod file indicates go 1.18, but maximum supported version is 1.17
make: *** [Makefile:60: go-fetch] Error 1
```
