### PR TITLE
feat(ci): add arm64 support for container image

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,8 @@ jobs:
     secrets: inherit
     with:
       scan: false
+      platforms: "linux/amd64,linux/arm64"
+      timeout: 40
   go-release:
     uses: lrstanley/.github/.github/workflows/lang-go-release.yml@master
     secrets: inherit

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,3 +35,6 @@ jobs:
     needs: [go-test, go-lint, node-lint, node-test]
     uses: lrstanley/.github/.github/workflows/docker-release.yml@master
     secrets: inherit
+    with:
+      platforms: "linux/amd64,linux/arm64"
+      timeout: 40

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,22 +1,28 @@
 # build-web image
-FROM oven/bun:1 AS build-web
-
-COPY . /build/
-WORKDIR /build/web
+FROM oven/bun:1-alpine AS build-web
 ENV NODE_ENV=production
-RUN bun install && bun run build
+# required by tree-sitter
+RUN apk add --no-cache python3 make g++
+WORKDIR /build/web
+COPY ./web/bun.lock ./web/package.json /build/web/
+# see https://github.com/thedotmack/claude-mem/issues/2280
+RUN CXXFLAGS="-std=c++20" CXX_STANDARD=20 bun install
+COPY ./internal/handlers/apihandler/openapi_v2.yaml /build/internal/handlers/apihandler/openapi_v2.yaml
+COPY ./web /build/web
+RUN bun run build
 
 # build-go image
 FROM golang:alpine AS build-go
-
-RUN apk add --no-cache make
+WORKDIR /build
+COPY go.* /build/
+RUN go mod download
 COPY . /build/
 COPY --from=build-web /build/web/dist/ /build/web/dist/
-WORKDIR /build
+RUN apk add --no-cache make
 RUN make go-build
 
 # runtime image
-FROM alpine:3.23
+FROM alpine:latest
 RUN apk add --no-cache ca-certificates
 COPY --from=build-go /build/geoip /usr/local/bin/geoip
 


### PR DESCRIPTION
## 🚀 Changes proposed by this PR

Added arm64 platform support for the built Docker image, along with some small changes to allow Docker to reuse cached build layers (especially when no dependencies have changed).

### 🧰 Type of change

- [X] Bug fix (non-breaking change which fixes an issue).

### 🤝 Requirements

- [X] ✍ I have read and agree to this projects [Code of Conduct](../../blob/master/.github/CODE_OF_CONDUCT.md).
- [X] ✍ I have read and agree to this projects [Contribution Guidelines](../../blob/master/.github/CONTRIBUTING.md).
- [X] ✍ I have read and agree to the [Developer Certificate of Origin](https://developercertificate.org/).
- [X] 🔎 I have performed a self-review of my own changes.
- [X] 🎨 My changes follow the style guidelines of this project.